### PR TITLE
NMP scale tweak

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -31,7 +31,7 @@ constexpr Score RFP_IMPROVING_MULTIPLIER = 66;
 
 constexpr Depth NULL_MOVE_DEPTH = 2;
 constexpr Depth NULL_MOVE_BASE_R = 4;
-constexpr Depth NULL_MOVE_R_SCALE = 2;
+constexpr Depth NULL_MOVE_R_SCALE = 3;
 
 constexpr Depth LMR_DEPTH = 3;
 constexpr double LMR_BASE = 0.1;


### PR DESCRIPTION
```
ELO   | 10.53 +- 5.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 8416 W: 2238 L: 1983 D: 4195
```