### PR TITLE
Add some missing includes

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 // clang-format off

--- a/src/move.h
+++ b/src/move.h
@@ -20,6 +20,7 @@
 
 #include "constants.h"
 #include "utils.h"
+#include <cstdint>
 
 constexpr unsigned int PROMO_FLAG = 0x8;    // 0b1000
 constexpr unsigned int CAPTURE_FLAG = 0x4;  // 0b0100

--- a/src/nnue.h
+++ b/src/nnue.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "bitboard.h"
+#include <cstdint>
 
 class Position;
 

--- a/src/tt.h
+++ b/src/tt.h
@@ -18,6 +18,7 @@
 
 #include "constants.h"
 #include "move.h"
+#include <cstdint>
 
 enum EntryFlag : uint8_t {
     TT_NONE = 0,


### PR DESCRIPTION
Couple of files are not including \<cstdint\> for fixed-width integer types such as uint32_t, breaking the build on Ubuntu 23.10 (GCC 13). So, add the missing includes.